### PR TITLE
feat: add support for claude, codex, pi sources

### DIFF
--- a/src/collector.ts
+++ b/src/collector.ts
@@ -1,116 +1,573 @@
-// Data collector - reads OpenCode storage and returns raw data
+// Data collector - reads Pi/Codex/Claude/OpenCode session files
 
-import { readdir } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
-import { xdgData } from "xdg-basedir";
-import type { SessionData, MessageData, ProjectData } from "./types";
+import { homedir } from "node:os";
+import type { DataSource, SessionData, MessageData, ProjectData } from "./types";
 
-const OPENCODE_DATA_PATH = join(xdgData!, "opencode/storage");
+const DATA_PATHS: Record<DataSource, string> = {
+  pi: join(homedir(), ".pi/agent/sessions"),
+  codex: join(homedir(), ".codex/sessions"),
+  claude: join(homedir(), ".claude/projects"),
+  opencode: join(homedir(), ".local/share/opencode/storage"),
+};
 
-export async function checkOpenCodeDataExists(): Promise<boolean> {
+export function getDataPath(source: DataSource): string {
+  return DATA_PATHS[source];
+}
+
+export async function checkDataExists(source: DataSource): Promise<boolean> {
   try {
-    await readdir(OPENCODE_DATA_PATH);
+    await readdir(DATA_PATHS[source]);
     return true;
   } catch {
     return false;
   }
 }
 
-export async function collectSessions(year?: number): Promise<SessionData[]> {
-  const sessionsPath = join(OPENCODE_DATA_PATH, "session");
+export async function getAvailableSources(): Promise<DataSource[]> {
+  const sources: DataSource[] = [];
+  for (const source of ["opencode", "claude", "codex", "pi"] as DataSource[]) {
+    if (await checkDataExists(source)) {
+      sources.push(source);
+    }
+  }
+  return sources;
+}
+
+function parseTimestamp(ts: string | number): number {
+  if (typeof ts === "number") return ts;
+  return new Date(ts).getTime();
+}
+
+// ============ Pi format (JSONL with session + messages) ============
+
+interface PiSessionLine {
+  type: "session";
+  id: string;
+  timestamp: string | number;
+  cwd: string;
+  provider: string;
+  modelId: string;
+}
+
+interface PiMessageLine {
+  type: "message";
+  timestamp: string | number;
+  message: {
+    role: "user" | "assistant" | "toolResult";
+    provider?: string;
+    model?: string;
+    usage?: {
+      input: number;
+      output: number;
+      cacheRead?: number;
+      cacheWrite?: number;
+      cost?: { total: number };
+    };
+  };
+}
+
+async function parsePiFile(
+  filePath: string,
+  year?: number
+): Promise<{ session: SessionData | null; messages: MessageData[] }> {
+  const messages: MessageData[] = [];
+  let session: SessionData | null = null;
 
   try {
-    const projectDirs = await readdir(sessionsPath);
+    const content = await Bun.file(filePath).text();
+    const lines = content.trim().split("\n");
 
-    const results = await Promise.all(
-      projectDirs.map(async (projectDir) => {
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      try {
+        const parsed = JSON.parse(line);
+
+        if (parsed.type === "session") {
+          const raw = parsed as PiSessionLine;
+          const timestamp = parseTimestamp(raw.timestamp);
+
+          if (year && new Date(timestamp).getFullYear() !== year) {
+            return { session: null, messages: [] };
+          }
+
+          session = {
+            id: raw.id,
+            timestamp,
+            cwd: raw.cwd,
+            provider: raw.provider,
+            modelId: raw.modelId,
+            source: "pi",
+          };
+        } else if (parsed.type === "message") {
+          const raw = parsed as PiMessageLine;
+          const timestamp = parseTimestamp(raw.timestamp);
+
+          if (year && new Date(timestamp).getFullYear() !== year) {
+            continue;
+          }
+
+          messages.push({
+            sessionId: session?.id ?? "",
+            role: raw.message.role,
+            timestamp,
+            provider: raw.message.provider,
+            modelId: raw.message.model,
+            usage: raw.message.usage,
+            source: "pi",
+          });
+        }
+      } catch {
+        // Skip malformed lines
+      }
+    }
+  } catch {
+    // Skip unreadable files
+  }
+
+  return { session, messages };
+}
+
+// ============ Claude Code format (JSONL with type: user/assistant) ============
+
+interface ClaudeLine {
+  type: "user" | "assistant";
+  sessionId: string;
+  cwd: string;
+  timestamp: string;
+  message: {
+    role: string;
+    model?: string;
+    usage?: {
+      input_tokens: number;
+      output_tokens: number;
+      cache_read_input_tokens?: number;
+      cache_creation_input_tokens?: number;
+    };
+  };
+  costUSD?: number;
+}
+
+async function parseClaudeFile(
+  filePath: string,
+  year?: number
+): Promise<{ sessions: Map<string, SessionData>; messages: MessageData[] }> {
+  const sessions = new Map<string, SessionData>();
+  const messages: MessageData[] = [];
+
+  try {
+    const content = await Bun.file(filePath).text();
+    const lines = content.trim().split("\n");
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      try {
+        const parsed = JSON.parse(line) as ClaudeLine;
+        if (!parsed.type || !parsed.sessionId) continue;
+
+        const timestamp = parseTimestamp(parsed.timestamp);
+        if (year && new Date(timestamp).getFullYear() !== year) continue;
+
+        // Track session
+        if (!sessions.has(parsed.sessionId)) {
+          sessions.set(parsed.sessionId, {
+            id: parsed.sessionId,
+            timestamp,
+            cwd: parsed.cwd,
+            provider: "anthropic",
+            modelId: parsed.message?.model || "claude",
+            source: "claude",
+          });
+        }
+
+        // Track message
+        if (parsed.type === "user" || parsed.type === "assistant") {
+          const usage = parsed.message?.usage;
+          messages.push({
+            sessionId: parsed.sessionId,
+            role: parsed.type,
+            timestamp,
+            provider: "anthropic",
+            modelId: parsed.message?.model,
+            usage: usage
+              ? {
+                  input: usage.input_tokens || 0,
+                  output: usage.output_tokens || 0,
+                  cacheRead: usage.cache_read_input_tokens,
+                  cacheWrite: usage.cache_creation_input_tokens,
+                }
+              : undefined,
+            source: "claude",
+          });
+        }
+      } catch {
+        // Skip malformed lines
+      }
+    }
+  } catch {
+    // Skip unreadable files
+  }
+
+  return { sessions, messages };
+}
+
+// ============ Codex CLI format (JSONL with session_meta, response_item, event_msg) ============
+
+interface CodexSessionMeta {
+  type: "session_meta";
+  timestamp: string;
+  payload: {
+    id: string;
+    cwd: string;
+    model_provider: string;
+  };
+}
+
+interface CodexResponseItem {
+  type: "response_item";
+  timestamp: string;
+  payload: {
+    role: "user" | "assistant";
+  };
+}
+
+interface CodexTokenCount {
+  type: "event_msg";
+  timestamp: string;
+  payload: {
+    type: "token_count";
+    info?: {
+      last_token_usage?: {
+        input_tokens: number;
+        output_tokens: number;
+        reasoning_output_tokens?: number;
+      };
+    };
+  };
+}
+
+async function parseCodexFile(
+  filePath: string,
+  year?: number
+): Promise<{ session: SessionData | null; messages: MessageData[] }> {
+  let session: SessionData | null = null;
+  const messages: MessageData[] = [];
+
+  try {
+    const content = await Bun.file(filePath).text();
+    const lines = content.trim().split("\n");
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      try {
+        const parsed = JSON.parse(line);
+
+        if (parsed.type === "session_meta") {
+          const raw = parsed as CodexSessionMeta;
+          const timestamp = parseTimestamp(raw.timestamp);
+
+          if (year && new Date(timestamp).getFullYear() !== year) {
+            return { session: null, messages: [] };
+          }
+
+          session = {
+            id: raw.payload.id,
+            timestamp,
+            cwd: raw.payload.cwd,
+            provider: raw.payload.model_provider || "openai",
+            modelId: "codex",
+            source: "codex",
+          };
+        } else if (parsed.type === "response_item") {
+          const raw = parsed as CodexResponseItem;
+          const timestamp = parseTimestamp(raw.timestamp);
+
+          if (year && new Date(timestamp).getFullYear() !== year) continue;
+
+          messages.push({
+            sessionId: session?.id ?? "",
+            role: raw.payload.role,
+            timestamp,
+            provider: session?.provider || "openai",
+            modelId: "codex",
+            source: "codex",
+          });
+        } else if (parsed.type === "event_msg" && parsed.payload?.type === "token_count") {
+          const raw = parsed as CodexTokenCount;
+          const usage = raw.payload.info?.last_token_usage;
+
+          // Update the last assistant message with usage
+          if (usage) {
+            for (let i = messages.length - 1; i >= 0; i--) {
+              if (messages[i].role === "assistant" && !messages[i].usage) {
+                messages[i].usage = {
+                  input: usage.input_tokens || 0,
+                  output: usage.output_tokens || 0,
+                };
+                break;
+              }
+            }
+          }
+        }
+      } catch {
+        // Skip malformed lines
+      }
+    }
+  } catch {
+    // Skip unreadable files
+  }
+
+  return { session, messages };
+}
+
+// ============ OpenCode format (separate JSON files for sessions and messages) ============
+
+interface OpenCodeSession {
+  id: string;
+  projectID: string;
+  directory: string;
+  time: { created: number; updated: number };
+}
+
+interface OpenCodeMessage {
+  id: string;
+  sessionID: string;
+  role: "user" | "assistant";
+  modelID?: string;
+  providerID?: string;
+  tokens?: {
+    input: number;
+    output: number;
+    reasoning?: number;
+    cache?: { read: number; write: number };
+  };
+  cost?: number;
+  time: { created: number };
+}
+
+async function collectOpenCode(
+  basePath: string,
+  year?: number
+): Promise<{
+  sessions: SessionData[];
+  messages: MessageData[];
+  projects: ProjectData[];
+}> {
+  const sessions: SessionData[] = [];
+  const allMessages: MessageData[] = [];
+  const projectMap = new Map<string, number>();
+
+  // Collect sessions
+  const sessionsPath = join(basePath, "session");
+  try {
+    const projectDirs = await readdir(sessionsPath);
+    await Promise.all(
+      projectDirs.map(async (projectDir: string) => {
         const projectPath = join(sessionsPath, projectDir);
         try {
           const sessionFiles = await readdir(projectPath);
-          return Promise.all(
+          await Promise.all(
             sessionFiles
-              .filter((f) => f.endsWith(".json"))
-              .map(async (sessionFile) => {
+              .filter((f: string) => f.endsWith(".json"))
+              .map(async (sessionFile: string) => {
                 try {
-                  const session = (await Bun.file(join(projectPath, sessionFile)).json()) as SessionData;
-                  if (year && new Date(session.time.created).getFullYear() !== year) return null;
-                  return session;
+                  const raw = (await Bun.file(join(projectPath, sessionFile)).json()) as OpenCodeSession;
+                  const timestamp = raw.time.created;
+
+                  if (year && new Date(timestamp).getFullYear() !== year) return;
+
+                  sessions.push({
+                    id: raw.id,
+                    timestamp,
+                    cwd: raw.directory,
+                    provider: "opencode",
+                    modelId: "opencode",
+                    source: "opencode",
+                  });
+
+                  projectMap.set(raw.directory, (projectMap.get(raw.directory) || 0) + 1);
                 } catch {
-                  return null;
+                  // Skip invalid files
                 }
               })
           );
         } catch {
-          return [];
+          // Skip inaccessible directories
         }
       })
     );
-
-    return results.flat().filter((s): s is SessionData => s !== null);
-  } catch (error) {
-    throw new Error(`Failed to read sessions: ${error}`);
+  } catch {
+    // Sessions directory doesn't exist
   }
-}
 
-export async function collectMessages(year?: number): Promise<MessageData[]> {
-  const messagesPath = join(OPENCODE_DATA_PATH, "message");
-
+  // Collect messages
+  const messagesPath = join(basePath, "message");
   try {
     const sessionDirs = await readdir(messagesPath);
-
-    const results = await Promise.all(
-      sessionDirs.map(async (sessionDir) => {
+    await Promise.all(
+      sessionDirs.map(async (sessionDir: string) => {
         const sessionPath = join(messagesPath, sessionDir);
         try {
           const messageFiles = await readdir(sessionPath);
-          return Promise.all(
+          await Promise.all(
             messageFiles
-              .filter((f) => f.endsWith(".json"))
-              .map(async (messageFile) => {
+              .filter((f: string) => f.endsWith(".json"))
+              .map(async (messageFile: string) => {
                 try {
-                  const message = (await Bun.file(join(sessionPath, messageFile)).json()) as MessageData;
-                  if (year && new Date(message.time.created).getFullYear() !== year) return null;
-                  return message;
+                  const raw = (await Bun.file(join(sessionPath, messageFile)).json()) as OpenCodeMessage;
+                  const timestamp = raw.time.created;
+
+                  if (year && new Date(timestamp).getFullYear() !== year) return;
+
+                  allMessages.push({
+                    sessionId: raw.sessionID,
+                    role: raw.role,
+                    timestamp,
+                    provider: raw.providerID,
+                    modelId: raw.modelID,
+                    usage: raw.tokens
+                      ? {
+                          input: raw.tokens.input || 0,
+                          output: raw.tokens.output || 0,
+                          cacheRead: raw.tokens.cache?.read,
+                          cacheWrite: raw.tokens.cache?.write,
+                        }
+                      : undefined,
+                    source: "opencode",
+                  });
                 } catch {
-                  return null;
+                  // Skip invalid files
                 }
               })
           );
         } catch {
-          return [];
+          // Skip inaccessible directories
         }
       })
     );
-
-    return results.flat().filter((m): m is MessageData => m !== null);
-  } catch (error) {
-    throw new Error(`Failed to read messages: ${error}`);
+  } catch {
+    // Messages directory doesn't exist
   }
+
+  const projects: ProjectData[] = Array.from(projectMap.entries()).map(([path, sessionCount]) => ({
+    path,
+    sessionCount,
+    source: "opencode",
+  }));
+
+  return { sessions, messages: allMessages, projects };
 }
 
-export async function collectProjects(): Promise<ProjectData[]> {
-  const projectsPath = join(OPENCODE_DATA_PATH, "project");
+// ============ Main collection functions ============
+
+async function findJsonlFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+
+  async function walk(currentDir: string) {
+    try {
+      const entries = await readdir(currentDir);
+      for (const entry of entries) {
+        const fullPath = join(currentDir, entry);
+        try {
+          const stats = await stat(fullPath);
+          if (stats.isDirectory()) {
+            await walk(fullPath);
+          } else if (entry.endsWith(".jsonl")) {
+            files.push(fullPath);
+          }
+        } catch {
+          // Skip inaccessible paths
+        }
+      }
+    } catch {
+      // Skip inaccessible directories
+    }
+  }
+
+  await walk(dir);
+  return files;
+}
+
+export async function collectAll(
+  source: DataSource,
+  year?: number
+): Promise<{
+  sessions: SessionData[];
+  messages: MessageData[];
+  projects: ProjectData[];
+}> {
+  const basePath = DATA_PATHS[source];
+  const sessions: SessionData[] = [];
+  const allMessages: MessageData[] = [];
+  const projectMap = new Map<string, number>();
 
   try {
-    const projectFiles = await readdir(projectsPath);
-    const jsonFiles = projectFiles.filter((f) => f.endsWith(".json"));
+    if (source === "opencode") {
+      const result = await collectOpenCode(basePath, year);
+      return result;
+    }
 
-    // Read all project files in parallel
-    const results = await Promise.all(
-      jsonFiles.map(async (projectFile) => {
-        try {
-          const filePath = join(projectsPath, projectFile);
-          const content = await Bun.file(filePath).json();
-          return content as ProjectData;
-        } catch {
-          return null; // Skip invalid JSON files
-        }
-      })
-    );
+    const jsonlFiles = await findJsonlFiles(basePath);
 
-    return results.filter((p): p is ProjectData => p !== null);
+    if (source === "pi") {
+      await Promise.all(
+        jsonlFiles.map(async (filePath: string) => {
+          const { session, messages } = await parsePiFile(filePath, year);
+
+          if (session) {
+            sessions.push(session);
+            const projectPath = session.cwd;
+            projectMap.set(projectPath, (projectMap.get(projectPath) || 0) + 1);
+          }
+          allMessages.push(...messages);
+        })
+      );
+    } else if (source === "claude") {
+      const allSessions = new Map<string, SessionData>();
+
+      await Promise.all(
+        jsonlFiles.map(async (filePath: string) => {
+          const { sessions: fileSessions, messages } = await parseClaudeFile(filePath, year);
+
+          for (const [id, session] of fileSessions) {
+            if (!allSessions.has(id)) {
+              allSessions.set(id, session);
+              const projectPath = session.cwd;
+              projectMap.set(projectPath, (projectMap.get(projectPath) || 0) + 1);
+            }
+          }
+          allMessages.push(...messages);
+        })
+      );
+
+      sessions.push(...allSessions.values());
+    } else if (source === "codex") {
+      await Promise.all(
+        jsonlFiles.map(async (filePath: string) => {
+          const { session, messages } = await parseCodexFile(filePath, year);
+
+          if (session) {
+            sessions.push(session);
+            const projectPath = session.cwd;
+            projectMap.set(projectPath, (projectMap.get(projectPath) || 0) + 1);
+          }
+          allMessages.push(...messages);
+        })
+      );
+    }
   } catch {
-    // Projects directory might not exist
-    return [];
+    // Directory doesn't exist
   }
+
+  const projects: ProjectData[] = Array.from(projectMap.entries()).map(([path, sessionCount]) => ({
+    path,
+    sessionCount,
+    source,
+  }));
+
+  return { sessions, messages: allMessages, projects };
 }

--- a/src/image/generator.tsx
+++ b/src/image/generator.tsx
@@ -2,7 +2,7 @@ import satori from "satori";
 import { Resvg, initWasm } from "@resvg/resvg-wasm";
 import resvgWasm from "@resvg/resvg-wasm/index_bg.wasm";
 import { WrappedTemplate } from "./template";
-import type { OpenCodeStats } from "../types";
+import type { WrappedStats } from "../types";
 import { loadFonts } from "./fonts";
 import { layout } from "./design-tokens";
 
@@ -13,7 +13,7 @@ export interface GeneratedImage {
   displaySize: Buffer;
 }
 
-export async function generateImage(stats: OpenCodeStats): Promise<GeneratedImage> {
+export async function generateImage(stats: WrappedStats): Promise<GeneratedImage> {
   await initWasm(Bun.file(resvgWasm).arrayBuffer());
 
   const svg = await satori(<WrappedTemplate stats={stats} />, {

--- a/src/image/template.tsx
+++ b/src/image/template.tsx
@@ -1,13 +1,17 @@
-import type { OpenCodeStats, WeekdayActivity } from "../types";
-import { formatNumber, formatCost, formatShortDate, formatDate } from "../utils/format";
+import type { WrappedStats, WeekdayActivity, DataSource } from "../types";
+import { formatNumber, formatCost, formatDate } from "../utils/format";
 import { ActivityHeatmap } from "./heatmap";
 import { getProviderLogoUrl } from "../models";
 import { colors, typography, spacing, layout, components } from "./design-tokens";
-import logo from "../../assets/images/opencode-wordmark-simple-dark.svg" with { type: 'text' }
 
-const OPENCODE_LOGO_DATA_URL = `data:image/svg+xml;base64,${Buffer.from(logo).toString("base64")}`;
+const SOURCE_DISPLAY: Record<DataSource, { name: string; tagline: string }> = {
+  opencode: { name: "OpenCode", tagline: "opencode.ai" },
+  claude: { name: "Claude Code", tagline: "Anthropic CLI" },
+  codex: { name: "Codex", tagline: "OpenAI CLI" },
+  pi: { name: "Pi", tagline: "shittycodingagent.ai" },
+};
 
-export function WrappedTemplate({ stats }: { stats: OpenCodeStats }) {
+export function WrappedTemplate({ stats }: { stats: WrappedStats }) {
   return (
     <div
       style={{
@@ -24,7 +28,7 @@ export function WrappedTemplate({ stats }: { stats: OpenCodeStats }) {
         paddingBottom: layout.padding.bottom,
       }}
     >
-      <Header year={stats.year} />
+      <Header year={stats.year} source={stats.source} />
 
       <div style={{ marginTop: spacing[12], display: "flex", flexDirection: "row", gap: spacing[16], alignItems: "flex-start" }}>
         <HeroStatItem
@@ -90,12 +94,14 @@ export function WrappedTemplate({ stats }: { stats: OpenCodeStats }) {
       </div>
 
       <StatsGrid stats={stats} />
-      <Footer />
+      <Footer source={stats.source} />
     </div>
   );
 }
 
-function Header({ year }: { year: number }) {
+function Header({ year, source }: { year: number; source: DataSource }) {
+  const display = SOURCE_DISPLAY[source];
+
   return (
     <div
       style={{
@@ -104,13 +110,16 @@ function Header({ year }: { year: number }) {
         gap: spacing[3],
       }}
     >
-      <img
-        src={OPENCODE_LOGO_DATA_URL}
-        height={160}
+      <span
         style={{
-          objectFit: "contain",
+          fontSize: typography.size["5xl"],
+          fontWeight: typography.weight.bold,
+          color: colors.text.primary,
+          lineHeight: typography.lineHeight.none,
         }}
-      />
+      >
+        {display.name}
+      </span>
 
       <span
         style={{
@@ -372,8 +381,8 @@ function RankingItemRow({ rank, name, logoUrl }: RankingItemRowProps) {
   );
 }
 
-function StatsGrid({ stats }: { stats: OpenCodeStats }) {
-  const hasZen = stats.hasZenUsage;
+function StatsGrid({ stats }: { stats: WrappedStats }) {
+  const hasCost = stats.totalCost > 0;
 
   return (
     <div
@@ -384,7 +393,7 @@ function StatsGrid({ stats }: { stats: OpenCodeStats }) {
         gap: spacing[5],
       }}
     >
-      {hasZen ? (
+      {hasCost ? (
         <div style={{ display: "flex", flexDirection: "column", gap: spacing[5] }}>
           <div style={{ display: "flex", gap: spacing[5] }}>
             <StatBox label="Sessions" value={formatNumber(stats.totalSessions)} />
@@ -395,7 +404,7 @@ function StatsGrid({ stats }: { stats: OpenCodeStats }) {
           <div style={{ display: "flex", gap: spacing[5] }}>
             <StatBox label="Projects" value={formatNumber(stats.totalProjects)} />
             <StatBox label="Streak" value={`${stats.maxStreak}d`} />
-            <StatBox label="OpenCode Zen Cost" value={formatCost(stats.totalCost)} />
+            <StatBox label="Cost" value={formatCost(stats.totalCost)} />
           </div>
         </div>
       ) : (
@@ -465,7 +474,9 @@ function StatBox({ label, value }: StatBoxProps) {
   );
 }
 
-function Footer() {
+function Footer({ source }: { source: DataSource }) {
+  const display = SOURCE_DISPLAY[source];
+
   return (
     <div
       style={{
@@ -484,7 +495,7 @@ function Footer() {
           letterSpacing: typography.letterSpacing.normal,
         }}
       >
-        opencode.ai
+        {display.tagline}
       </span>
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,58 +1,38 @@
-// Types for OpenCode Wrapped
+// Types for CLI Wrapped
+
+export type DataSource = "opencode" | "claude" | "codex" | "pi";
 
 export interface SessionData {
   id: string;
-  version: string;
-  projectID: string;
-  directory: string;
-  title: string;
-  time: {
-    created: number;
-    updated: number;
-  };
-  summary?: {
-    additions: number;
-    deletions: number;
-    files: number;
-  };
+  timestamp: number; // epoch ms
+  cwd: string;
+  provider: string;
+  modelId: string;
+  source: DataSource;
 }
 
 export interface MessageData {
-  id: string;
-  sessionID: string;
-  role: "user" | "assistant";
-  time: {
-    created: number;
-    completed?: number;
-  };
-  parentID?: string;
-  modelID?: string;
-  providerID?: string;
-  mode?: string;
-  agent?: string;
-  cost?: number;
-  tokens?: {
+  sessionId: string;
+  role: "user" | "assistant" | "toolResult";
+  timestamp: number;
+  provider?: string;
+  modelId?: string;
+  usage?: {
     input: number;
     output: number;
-    reasoning: number;
-    cache: {
-      read: number;
-      write: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    cost?: {
+      total: number;
     };
   };
-  finish?: string;
+  source: DataSource;
 }
 
 export interface ProjectData {
-  id: string;
-  worktree: string;
-  vcsDir: string;
-  vcs: string;
-  time: {
-    created: number;
-    updated: number;
-    initialized?: number;
-  };
+  path: string;
+  sessionCount: number;
+  source: DataSource;
 }
 
 export interface ModelStats {
@@ -70,8 +50,9 @@ export interface ProviderStats {
   percentage: number;
 }
 
-export interface OpenCodeStats {
+export interface WrappedStats {
   year: number;
+  source: DataSource;
 
   // Time-based
   firstSessionDate: Date;
@@ -87,9 +68,8 @@ export interface OpenCodeStats {
   totalOutputTokens: number;
   totalTokens: number;
 
-  // Cost (only from OpenCode/Zen provider)
+  // Cost
   totalCost: number;
-  hasZenUsage: boolean;
 
   // Models (sorted by usage)
   topModels: ModelStats[];
@@ -100,10 +80,10 @@ export interface OpenCodeStats {
   // Streak
   maxStreak: number;
   currentStreak: number;
-  maxStreakDays: Set<string>; // Days that form the max streak (for heatmap highlighting)
+  maxStreakDays: Set<string>;
 
   // Activity heatmap (for the year)
-  dailyActivity: Map<string, number>; // "2025-01-15" -> count
+  dailyActivity: Map<string, number>;
 
   // Most active day
   mostActiveDay: {
@@ -116,6 +96,9 @@ export interface OpenCodeStats {
   weekdayActivity: WeekdayActivity;
 }
 
+// Keep OpenCodeStats as alias for compatibility
+export type OpenCodeStats = WrappedStats;
+
 export interface WeekdayActivity {
   counts: [number, number, number, number, number, number, number];
   mostActiveDay: number;
@@ -125,5 +108,6 @@ export interface WeekdayActivity {
 
 export interface CliArgs {
   year?: number;
+  source?: DataSource;
   help?: boolean;
 }


### PR DESCRIPTION
## **Description:**

Adds multi-source support for AI coding agent session data.
### Sources
| Source | Path | Format |
|--------|------|--------|
| OpenCode | `~/.local/share/opencode/storage/` | JSON files |
| Claude Code | `~/.claude/projects/` | JSONL |
| Codex | `~/.codex/sessions/` | JSONL |
| Pi | `~/.pi/agent/sessions/` | JSONL |
### Changes
- Add `--source` flag to select data source
- Auto-detect available sources, prompt if multiple found
- Source-specific branding in generated image (name + tagline)
- Parsers for each source's session format
### Usage
```bash
oc-wrapped                    # auto-detect
oc-wrapped --source claude    # specific source
```